### PR TITLE
add validate-pre-commit-revs hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,14 +2,15 @@
 repos:
   # SAST: Configuration
   - repo: https://github.com/jonny-wg2/pre-commit-sast
-    rev: v0.0.3
+    rev: d2a8229042fbfb25c79514a075d8f1b029c157d1
     hooks:
       - id: trivyconfig
         args:
           - "--args=--severity HIGH,CRITICAL"
+      # - id: validate-pre-commit-revs
   # SAST: Semgrep
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.137.0
+    rev: 8b4b26313328afdbbb30470cc09d3b7de643e7e6
     hooks:
       - id: semgrep
         name: "SAST:semgrep-ci (exclude findings with commenting) [# nosemgrep]"
@@ -35,10 +36,10 @@ repos:
         stages: [commit]
   # SAST: Erlang Pest https://github.com/okeuday/pest
   - repo: https://github.com/omnicate/pre-commit-erlang-pest
-    rev: v1.0.4
+    rev: b878bf7314d7537c69cbcbb17d7e45a928e27ae6
     hooks:
       - id: pest
   - repo: https://github.com/syntaqx/git-hooks
-    rev: v0.0.18
+    rev: a3b888f92cd5b40b270c9a9752181fdc1717cbe5
     hooks:
       - id: shellcheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,12 @@
 repos:
   # SAST: Configuration
   - repo: https://github.com/jonny-wg2/pre-commit-sast
-    rev: d2a8229042fbfb25c79514a075d8f1b029c157d1
+    rev: bf2ab7d452c8557b5be44dabe25d09946a785d4e
     hooks:
       - id: trivyconfig
         args:
           - "--args=--severity HIGH,CRITICAL"
-      # - id: validate-pre-commit-revs
+      - id: validate-pre-commit-revs
   # SAST: Semgrep
   - repo: https://github.com/returntocorp/semgrep
     rev: 8b4b26313328afdbbb30470cc09d3b7de643e7e6

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,3 +5,11 @@
   language: script
   types_or: [yaml, json, dockerfile, terraform]
   require_serial: true # Prevent cache corruption from concurrent scans, runs a single trivy invocation per file
+
+- id: validate-pre-commit-revs
+  name: Validate pre-commit revs
+  description: "Require remote pre-commit repos to pin rev to a full 40-character git SHA."
+  entry: validate-pre-commit-revs
+  language: golang
+  files: ^\.pre-commit-config\.yaml$
+  pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ SHA. This prevents floating tags and short SHAs in `.pre-commit-config.yaml`.
 
 ```yaml
 - repo: https://github.com/jonny-wg2/pre-commit-sast
-  rev: d2a8229042fbfb25c79514a075d8f1b029c157d1
+  rev: bf2ab7d452c8557b5be44dabe25d09946a785d4e
   hooks:
     - id: validate-pre-commit-revs
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 
 Repo containing hooks for SAST tools. Check out `.pre-commit-config.yaml` for additional SAST tools.
 
+## Validate pre-commit revs
+
+Require remote pre-commit repos to pin `rev` to a full 40-character git
+SHA. This prevents floating tags and short SHAs in `.pre-commit-config.yaml`.
+
+### Rules
+
+- Remote repos must use a 40-character lowercase git SHA in `rev`
+- `repo: local` and `repo: meta` are exempt and must not define `rev`
+
+### Usage
+
+```yaml
+- repo: https://github.com/jonny-wg2/pre-commit-sast
+  rev: d2a8229042fbfb25c79514a075d8f1b029c157d1
+  hooks:
+    - id: validate-pre-commit-revs
+```
+
+This hook runs the shared Go implementation from this repository.
+It is packaged as a `golang` pre-commit hook.
+
 ## Trivy
 
 Trivy configuration scanner with batch scanning for improved reliability.
@@ -16,7 +38,7 @@ Trivy configuration scanner with batch scanning for improved reliability.
 
 ```yaml
 - repo: https://github.com/jonny-wg2/pre-commit-sast
-  rev: v0.0.3
+  rev: d2a8229042fbfb25c79514a075d8f1b029c157d1
   hooks:
     - id: trivyconfig
       args:

--- a/cmd/validate-pre-commit-revs/main.go
+++ b/cmd/validate-pre-commit-revs/main.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+
+	"gopkg.in/yaml.v3"
+)
+
+const configPath = ".pre-commit-config.yaml"
+
+var shaPattern = regexp.MustCompile("^[0-9a-f]{40}$")
+
+type config struct {
+	Repos []repo `yaml:"repos"`
+}
+
+type repo struct {
+	Repo string `yaml:"repo"`
+	Rev  string `yaml:"rev"`
+}
+
+func main() {
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s not found: %v\n", configPath, err)
+		os.Exit(1)
+	}
+
+	var cfg config
+	if err := yaml.Unmarshal(content, &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to parse %s: %v\n", configPath, err)
+		os.Exit(1)
+	}
+
+	var errors []string
+	for i, entry := range cfg.Repos {
+		if entry.Repo == "" {
+			errors = append(
+				errors,
+				fmt.Sprintf(
+					"repos[%d] is missing a valid 'repo' value",
+					i+1,
+				),
+			)
+			continue
+		}
+
+		if entry.Repo == "local" || entry.Repo == "meta" {
+			if entry.Rev != "" {
+				errors = append(
+					errors,
+					fmt.Sprintf(
+						"repos[%d] repo %q must not define 'rev'",
+						i+1,
+						entry.Repo,
+					),
+				)
+			}
+			continue
+		}
+
+		if !shaPattern.MatchString(entry.Rev) {
+			errors = append(
+				errors,
+				fmt.Sprintf(
+					"repos[%d] repo %q must use a full 40-character SHA for 'rev' (got %q)",
+					i+1,
+					entry.Repo,
+					entry.Rev,
+				),
+			)
+		}
+	}
+
+	if len(errors) > 0 {
+		fmt.Fprintln(
+			os.Stderr,
+			"Invalid .pre-commit-config.yaml: remote repos must pin 'rev' to a full 40-character git SHA. Only 'local' and 'meta' repos are exempt.",
+		)
+		for _, err := range errors {
+			fmt.Fprintf(os.Stderr, "  - %s\n", err)
+		}
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/jonny-wg2/pre-commit-sast
+
+go 1.25.2
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Require SHA for pre-commit hooks to prevent attacks like https://www.crowdstrike.com/en-us/blog/from-scanner-to-stealer-inside-the-trivy-action-supply-chain-compromise/

Once merged, will update all pre-commit-configs and revs to ensure we leverage shas