### PR TITLE
specify minimum go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/jonny-wg2/pre-commit-sast
 
-go 1.25.2
+go 1.23
 
 require gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
Fix error
```
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/go', 'install', './...')
return code: 1
stdout: (none)
stderr:
    go: errors parsing go.mod:
    /root/.cache/pre-commit/repovuzqr2hu/go.mod:3: invalid go version '1.25.2': must match format 1.23
Check the log at /root/.cache/pre-commit/pre-commit.log
    </pre>
    </body>
    </html>
```